### PR TITLE
Bump gson and feign versions

### DIFF
--- a/features/forgerock.key.manager.feature/pom.xml
+++ b/features/forgerock.key.manager.feature/pom.xml
@@ -78,11 +78,6 @@
                                 </properties>
                             </adviceFile>
                             <bundles>
-                                <bundleDef>com.google.code.gson:gson:${gson.version}</bundleDef>
-                                <bundleDef>io.github.openfeign:feign-core:${feign.version}</bundleDef>
-                                <bundleDef>io.github.openfeign:feign-gson:${feign.version}</bundleDef>
-                                <bundleDef>io.github.openfeign:feign-okhttp:${feign.version}</bundleDef>
-                                <bundleDef>io.github.openfeign:feign-slf4j:${feign.version}</bundleDef>
                                 <bundleDef>org.wso2.km.ext.forgerock:forgerock.key.manager:${project.version}</bundleDef>
                             </bundles>
                         </configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -95,7 +95,7 @@
         <repository>
             <id>wso2-nexus</id>
             <name>WSO2 internal Repository</name>
-            <url>http://maven.wso2.org/nexus/content/groups/wso2-public/</url>
+            <url>https://maven.wso2.org/nexus/content/groups/wso2-public/</url>
             <releases>
                 <enabled>true</enabled>
                 <updatePolicy>daily</updatePolicy>
@@ -105,7 +105,7 @@
         <repository>
             <id>wso2.releases</id>
             <name>WSO2 internal Repository</name>
-            <url>http://maven.wso2.org/nexus/content/repositories/releases/</url>
+            <url>https://maven.wso2.org/nexus/content/repositories/releases/</url>
             <releases>
                 <enabled>true</enabled>
                 <updatePolicy>daily</updatePolicy>
@@ -115,7 +115,7 @@
         <repository>
             <id>wso2.snapshots</id>
             <name>Apache Snapshot Repository</name>
-            <url>http://maven.wso2.org/nexus/content/repositories/snapshots/</url>
+            <url>https://maven.wso2.org/nexus/content/repositories/snapshots/</url>
             <snapshots>
                 <enabled>true</enabled>
                 <updatePolicy>daily</updatePolicy>
@@ -165,7 +165,7 @@
         <repository>
             <id>nexus-releases</id>
             <name>WSO2 Release Distribution Repository</name>
-            <url>http://maven.wso2.org/nexus/service/local/staging/deploy/maven2/</url>
+            <url>https://maven.wso2.org/nexus/service/local/staging/deploy/maven2/</url>
         </repository>
         <snapshotRepository>
             <id>wso2.snapshots</id>
@@ -183,9 +183,9 @@
     <properties>
         <carbon.apimgt.version>6.7.206</carbon.apimgt.version>
         <carbon.apimgt.imp.pkg.version>[6.7.0, 10.0.0)</carbon.apimgt.imp.pkg.version>
-        <json.simple.version>1.1</json.simple.version>
-        <gson.version>2.1</gson.version>
+        <json.simple.version>1.1.1</json.simple.version>
+        <gson.version>2.10.1</gson.version>
         <carbon.p2.plugin.version>1.5.3</carbon.p2.plugin.version>
-        <feign.version>11.0</feign.version>
+        <feign.version>13.2.1</feign.version>
     </properties>
 </project>


### PR DESCRIPTION
This PR will bump following dependencies 

Gson - 2.1 -> 2.10.1
Feign - 11.0 -> 13.2.1
Json.simple - 1.1 -> 1.1.1