### PR TITLE
Send client type when updating the application

### DIFF
--- a/components/forgerock.key.manager/src/main/java/org/wso2/forgerock/client/ForgerockOAuthClient.java
+++ b/components/forgerock.key.manager/src/main/java/org/wso2/forgerock/client/ForgerockOAuthClient.java
@@ -144,6 +144,7 @@ public class ForgerockOAuthClient extends AbstractKeyManager {
             clientInfoFromForgerock.setResponseTypes(clientInfo.getResponseTypes());
             clientInfoFromForgerock.setGrantTypes(clientInfo.getGrantTypes());
             clientInfoFromForgerock.setTokenEndpointAuthMethod(clientInfo.getTokenEndpointAuthMethod());
+            clientInfoFromForgerock.setClientType(clientInfo.getClientType());
             ClientInfo updatedClientInfo = forgeDCRClient.updateApplication(clientId, clientInfoFromForgerock);
             if (log.isDebugEnabled()) {
                 log.debug(String.format("Updating an OAuth client in Forgerock authorization server for the" +


### PR DESCRIPTION
Related issue: https://github.com/wso2/api-manager/issues/3580

When updating the application, the client type is not sent to Forgerock. This fix will add the `clientType` property to the request sent to Forgerock.